### PR TITLE
Fix NetworkManager D-Bus type registration and Speed property reading

### DIFF
--- a/libs/network-utils/src/common/dbus_types.cpp
+++ b/libs/network-utils/src/common/dbus_types.cpp
@@ -123,8 +123,18 @@ void registerDbusTypes() {
 
     // Ensure QVariantMap and QList<QVariantMap> are registered for D-Bus,
     // as they are used in properties (e.g. AddressData aa{sv})
-    qDBusRegisterMetaType<QMap<QString, QVariant>>();      // For QVariantMap
-    qDBusRegisterMetaType<QList<QMap<QString, QVariant>>>();// For QList<QVariantMap>
+
+    // Typedefs for clarity (can be placed at function scope or wider if needed)
+    typedef QMap<QString, QVariant> QVariantMapType;
+    typedef QList<QVariantMapType>  QVariantMapListType;
+
+    // Register QVariantMap (a{sv})
+    qRegisterMetaType<QVariantMapType>("QVariantMapType"); // For QVariant system
+    qDBusRegisterMetaType<QVariantMapType>();             // For D-Bus signature a{sv}
+
+    // Register QList<QVariantMap> (aa{sv})
+    qRegisterMetaType<QVariantMapListType>("QVariantMapListType"); // For QVariant system
+    qDBusRegisterMetaType<QVariantMapListType>();                  // For D-Bus signature aa{sv}
 
     // Attempt to explicitly register marshalling operators for QList<QVariantMap>
     // This might help with property system if it's not picking them up automatically.


### PR DESCRIPTION
This commit addresses two issues related to NetworkManager D-Bus interactions:

1.  **Register `aa{sv}` D-Bus type**: The D-Bus type `aa{sv}` (array of string-to-variant dictionaries), used by NetworkManager for properties like AddressData and NameserverData, was not fully registered with Qt's metatype and D-Bus systems. This caused "Unregistered type QDBusRawType<0x61617b73767d>*" errors. This change adds the necessary `qRegisterMetaType` calls for `QMap<QString, QVariant>` (as `QVariantMapType`) and `QList<QVariantMap>` (as `QVariantMapListType`) in `NetworkUtils::registerDbusTypes()` in `dbus_types.cpp`, alongside the existing `qDBusRegisterMetaType` calls.

2.  **Improve 'Speed' property reading**: The 'Speed' property (uint32) from `org.freedesktop.NetworkManager.Device` was being read using `toULongLong()`. This has been changed to `toUInt()` for type correctness. Diagnostic logging around reading this property has also been improved in `QtNetworkManager::getInterfaceDetails`.

Modified files:
- libs/network-utils/src/common/dbus_types.cpp
- libs/network-utils/src/networkmanager/QtNetworkManager.cpp