### PR TITLE
Move D-Bus type registration earlier and add debug logs

### DIFF
--- a/libs/network-utils/src/common/dbus_types.cpp
+++ b/libs/network-utils/src/common/dbus_types.cpp
@@ -12,6 +12,7 @@
 #include <QMetaType>
 #include <QDBusMetaType> // For qDBusRegisterMetaType
 #include <QList>
+#include <QDebug> // Added for debug output
 #include <QDBusArgument> // For implementing streaming operators
 
 // Q_DECLARE_METATYPE for individual types are in their respective headers (e.g. port.h)
@@ -95,6 +96,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, StaticRoute& val)
 
 namespace NetworkUtils {
 void registerDbusTypes() {
+    qDebug() << "NetworkUtils::registerDbusTypes() called - start";
     // Firewalld Types (operators are inline in dbus_types.h)
     // Their Q_DECLARE_METATYPE is in their respective headers.
     // QList<T> Q_DECLARE_METATYPE calls were removed from dbus_types.h.

--- a/main.cpp
+++ b/main.cpp
@@ -6,9 +6,10 @@
 
 int main(int argc, char *argv[])
 {
-    QCoreApplication a(argc, argv);
-    NetworkUtils::registerDbusTypes(); // Register custom types
+    qDebug() << "main() called - start";
+    NetworkUtils::registerDbusTypes(); // Register custom types VERY FIRST
 
+    QCoreApplication a(argc, argv);
     QtFirewalldManager man;
     const auto zones = man.zoneNames();
 


### PR DESCRIPTION
To help diagnose persistent 'Unregistered D-Bus type' errors:

1.  I moved the call to `NetworkUtils::registerDbusTypes()` to be the first operational line in `main()` in `main.cpp`. This ensures custom D-Bus types are registered before any other Qt D-Bus initialization might occur.
2.  I added `qDebug()` statements at the start of `main()` and `NetworkUtils::registerDbusTypes()` to verify their execution order when the application runs.

Modified files:
- main.cpp
- libs/network-utils/src/common/dbus_types.cpp