### PR TITLE
Here's a refined D-Bus type registration for `aa{sv}` and `a{sv}`.

### DIFF
--- a/libs/network-utils/include/network-utils/types/dbus_types.h
+++ b/libs/network-utils/include/network-utils/types/dbus_types.h
@@ -14,6 +14,7 @@
 
 #include <QMetaType>
 #include <QList> // Required for QList<T>
+#include <QVariantMap> // Required for QVariantMap
 
 // Forward declaration for QDBusArgument to allow operator declarations first
 class QDBusArgument;
@@ -81,6 +82,8 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, StaticRoute& val)
 // Metatype declarations for QList<T> are REMOVED to prevent auto-streaming attempts for lists.
 // Individual types (Port, Service, IpAddress, etc.) have Q_DECLARE_METATYPE in their own headers.
 
+Q_DECLARE_METATYPE(QVariantMap);
+Q_DECLARE_METATYPE(QList<QVariantMap>);
 
 namespace NetworkUtils {
     void registerDbusTypes();

--- a/libs/network-utils/src/common/dbus_types.cpp
+++ b/libs/network-utils/src/common/dbus_types.cpp
@@ -126,17 +126,15 @@ void registerDbusTypes() {
     // Ensure QVariantMap and QList<QVariantMap> are registered for D-Bus,
     // as they are used in properties (e.g. AddressData aa{sv})
 
-    // Typedefs for clarity (can be placed at function scope or wider if needed)
-    typedef QMap<QString, QVariant> QVariantMapType;
-    typedef QList<QVariantMapType>  QVariantMapListType;
+    // Register QVariantMap (D-Bus type a{sv})
+    // String name for qRegisterMetaType should be unique and descriptive.
+    qRegisterMetaType<QVariantMap>("QVariantMap");
+    qDBusRegisterMetaType<QVariantMap>(); // Registers for D-Bus, uses Qt's internal signature for a{sv}
 
-    // Register QVariantMap (a{sv})
-    qRegisterMetaType<QVariantMapType>("QVariantMapType"); // For QVariant system
-    qDBusRegisterMetaType<QVariantMapType>();             // For D-Bus signature a{sv}
-
-    // Register QList<QVariantMap> (aa{sv})
-    qRegisterMetaType<QVariantMapListType>("QVariantMapListType"); // For QVariant system
-    qDBusRegisterMetaType<QVariantMapListType>();                  // For D-Bus signature aa{sv}
+    // Register QList<QVariantMap> (D-Bus type aa{sv})
+    // String name for qRegisterMetaType should be unique and descriptive.
+    qRegisterMetaType<QList<QVariantMap>>("QList<QVariantMap>");
+    qDBusRegisterMetaType<QList<QVariantMap>>(); // Registers for D-Bus, uses Qt's internal signature for aa{sv}
 
     // Attempt to explicitly register marshalling operators for QList<QVariantMap>
     // This might help with property system if it's not picking them up automatically.


### PR DESCRIPTION
This update includes several changes to ensure `QVariantMap` (a{sv}) and `QList<QVariantMap>` (aa{sv}) are correctly registered for D-Bus:

1.  **Ensured `NetworkUtils::registerDbusTypes()` is called early**: I moved the call to `NetworkUtils::registerDbusTypes()` to be the first operational line in `main()`. I also included debug logs to verify the order.

2.  **Explicitly declared metatypes using `Q_DECLARE_METATYPE`**: I added `Q_DECLARE_METATYPE(QVariantMap);` and `Q_DECLARE_METATYPE(QList<QVariantMap>);` to `libs/network-utils/include/network-utils/types/dbus_types.h`. This makes the types known to Qt's meta-object system at compile time.

3.  **Re-verified type registration calls in `dbus_types.cpp`**: I updated `NetworkUtils::registerDbusTypes()` to use direct type names (`QVariantMap`, `QList<QVariantMap>`) for `qRegisterMetaType` (with string name) and `qDBusRegisterMetaType`. I removed previous typedefs for these calls to ensure clarity and consistency.

These changes aim to resolve the persistent "Unregistered type QDBusRawType<0x61617b73767d>*" errors.

I modified the following files:
- libs/network-utils/include/network-utils/types/dbus_types.h
- libs/network-utils/src/common/dbus_types.cpp (main.cpp and dbus_types.cpp were also modified for debug logs and call order in a previous related update)