### PR TITLE
Remove Speed property and re-test aa{sv} D-Bus registration

### DIFF
--- a/libs/network-utils/include/network-utils/types/interface_details.h
+++ b/libs/network-utils/include/network-utils/types/interface_details.h
@@ -23,6 +23,5 @@ struct InterfaceDetails {
     QList<StaticRoute> staticRoutes; // Configured static routes for this interface
 
     bool isUp = false;
-    quint64 speed = 0; // Speed in Mbps, or some standard unit (e.g., kbit/s as NM often uses)
     // Add other relevant details like duplex, state string from NM, etc.
 };

--- a/libs/network-utils/src/networkmanager/QtNetworkManager.cpp
+++ b/libs/network-utils/src/networkmanager/QtNetworkManager.cpp
@@ -351,35 +351,6 @@ InterfaceDetails QtNetworkManager::getInterfaceDetails(const QString &interfaceN
         qWarning() << "Could not read State for" << interfaceName << ":" << deviceIface->lastError().message();
     }
 
-    qDebug() << "Attempting to read Speed property for" << interfaceName << "using QDBusInterface::property().";
-    QVariant speedVar = deviceIface->property("Speed"); // RESTORED
-    qDebug() << "  speedVar.isValid():" << speedVar.isValid();
-    if (speedVar.isValid()) {
-        qDebug() << "  speedVar.metaType().id():" << speedVar.metaType().id();
-        qDebug() << "  speedVar.metaType().name():" << speedVar.metaType().name();
-        qDebug() << "  speedVar.userType():" << speedVar.userType();
-        qDebug() << "  Expected QMetaType for quint32: id" << QMetaType::fromType<quint32>().id()
-                 << "name" << QMetaType::fromType<quint32>().name();
-        qDebug() << "  Is speedVar.metaType() == QMetaType::fromType<quint32>() ?" << (speedVar.metaType() == QMetaType::fromType<quint32>());
-
-        // Existing conversion logic (from before call("Get") was introduced)
-        if (speedVar.canConvert<quint32>()) { // Check canConvert based on the new diagnostics
-            details.speed = speedVar.toUInt();
-            if (details.speed == 0) {
-                qDebug() << "Speed for" << interfaceName << "is reported as 0.";
-            }
-        } else {
-             qWarning() << "Speed property for" << interfaceName << "is valid, but not convertible to quint32. Value:" << speedVar;
-             details.speed = 0;
-        }
-    } else {
-        qDebug() << "  speedVar is invalid (from property()).";
-        qDebug() << "    Error from specific interface (" << deviceIface->service() << deviceIface->path() << "):" << deviceIface->lastError().message();
-        qDebug() << "    Error from m_dbusConnection (" << m_dbusConnection.name() << "):" << m_dbusConnection.lastError().message();
-        qDebug() << "    Error from QDBusConnection::systemBus (" << QDBusConnection::systemBus().name() << "):" << QDBusConnection::systemBus().lastError().message();
-        details.speed = 0; // Default to 0 if unable to read
-    }
-
     QVariant ip4ConfigPathVar = deviceIface->property("Ip4Config");
     if (!ip4ConfigPathVar.isValid() || !ip4ConfigPathVar.canConvert<QDBusObjectPath>()) {
         qWarning() << "Could not read Ip4Config path for" << interfaceName << ":" << deviceIface->lastError().message();


### PR DESCRIPTION
This commit includes two main changes:

1.  **Remove 'Speed' Property Handling**: As per your request, the 'Speed' D-Bus property is no longer used.
    - Removed the `speed` member from the `InterfaceDetails` struct.
    - Removed all code related to fetching, processing, or logging the "Speed" property from `QtNetworkManager::getInterfaceDetails`.

2.  **Prepare for Re-testing `aa{sv}` Property Access**:
    - Property access for "AddressData" and "NameserverData" continues to use `QDBusInterface::property()`.
    - The comprehensive D-Bus type registration logic for `QVariantMap` and `QList<QVariantMap>` (including `Q_DECLARE_METATYPE`, early call to `registerDbusTypes()`, and explicit type names in `qRegisterMetaType`/`qDBusRegisterMetaType`) remains in place.
    - Detailed `QVariant` MetaType diagnostics also remain in place for the `QVariant`s returned by `property()` for "AddressData" and "NameserverData".

This set of changes focuses the debugging effort entirely on the persistent "Unregistered type" errors for `aa{sv}` properties.

Modified files:
- libs/network-utils/include/network-utils/types/interface_details.h
- libs/network-utils/src/networkmanager/QtNetworkManager.cpp